### PR TITLE
Update PNGImage.as

### DIFF
--- a/alivepdf/src/org/alivepdf/images/PNGImage.as
+++ b/alivepdf/src/org/alivepdf/images/PNGImage.as
@@ -81,7 +81,7 @@ package org.alivepdf.images
 					
 				} else if ( type == PNGImage.TRNS )
 				{
-					
+					throw new Error("PNG simple transparency mode is not supported");
 					
 				} else if ( type == PNGImage.IDAT )
 				{	


### PR DESCRIPTION
Throw error message for unsupported PNG transparency mode instead of failing silently.